### PR TITLE
chore: bump Go version to 1.24.13 to fix CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gork74/aws-parameter-bulk
 
-go 1.23.0
+go 1.24.13
 
 require (
 	github.com/alexedwards/scs/v2 v2.9.0


### PR DESCRIPTION
## Bump Go version to fix CVE-2025-68121

### Purpose
Addresses CVE-2025-68121, a vulnerability in the Go standard library that 
affects binaries built with Go versions prior to 1.24.13, 1.25.7, or 1.26.0.

### Changes
- Upgrades `go.mod` from Go 1.23.0 → Go 1.24.13
- This is the minimal patch version that includes the CVE fix
- No code changes required; this affects build tooling only

### Testing
- Run full test suite to ensure compatibility with Go 1.24.13
- Verify binaries are produced successfully

### References
- CVE-2025-68121: Go vulnerability (fix available in Go 1.24.13+, 1.25.7+, 1.26.0+)